### PR TITLE
Improve prompt processing resilience

### DIFF
--- a/index.html
+++ b/index.html
@@ -2917,33 +2917,47 @@ Transcript follows:`,
 
         function downloadConsolidatedReport() {
             const date = new Date().toISOString().split('T')[0];
-            let output = `# AI Analysis Results - ${date}\n\n`;
-            
+
             // Map prompt keys to custom section titles
             const sectionTitles = {
                 "highlights_reflection": "# High/Low Light and Reflection",
                 "todo_list": "# TodoList",
                 "daily_chart": "# DailyChart",
-                "suggestion": "# Suggestion", 
+                "suggestion": "# Suggestion",
                 "summary": "# Summary",
                 "daily_logs": "# Daily Logs",
                 "new_learning": "# New Learning"
             };
-            
+
             // Get responses in order based on enabled prompts
             const enabledPrompts = getEnabledPrompts();
             const orderedPrompts = Object.entries(enabledPrompts)
                 .sort(([,a], [,b]) => (a.order || 999) - (b.order || 999));
-            
+
+            const sections = [];
+            const missingSections = [];
+
             orderedPrompts.forEach(([key, data]) => {
+                const title = sectionTitles[key] || `# ${data.name}`;
+
                 if (key in state.responses) {
-                    const title = sectionTitles[key] || `# ${data.name}`;
-                    output += `${title}\n\n`;
-                    output += state.responses[key];
-                    output += '\n\n---\n\n';
+                    sections.push(`${title}\n\n${state.responses[key]}\n\n---\n\n`);
+                } else {
+                    missingSections.push(data.name);
+                    sections.push(`${title}\n\n> ⚠️ Result not available yet. Re-run this prompt to generate content.\n\n---\n\n`);
                 }
             });
-            
+
+            let output = `# AI Analysis Results - ${date}\n\n`;
+
+            if (missingSections.length > 0) {
+                const pendingList = missingSections.join(', ');
+                output += `> ⚠️ The following sections are incomplete: ${pendingList}.\n`;
+                output += `> Resume processing to fill them in, or export again once they finish.\n\n---\n\n`;
+            }
+
+            output += sections.join('');
+
             const blob = new Blob([output], { type: 'text/markdown' });
             const url = URL.createObjectURL(blob);
             const a = document.createElement('a');

--- a/index.html
+++ b/index.html
@@ -1359,7 +1359,8 @@
             autoRotate: false,
             currentRotationIndex: 0,
             availableKeys: [],
-            selectedModel: 'gemini-2.5-pro'
+            selectedModel: 'gemini-2.5-pro',
+            lastTranscript: ''
         };
 
         // Default prompts configuration with metadata
@@ -2673,44 +2674,68 @@ Transcript follows:`,
             const transcript = transcriptInput.value.trim();
             if (!transcript || (!state.apiKey && !(state.autoRotate && state.availableKeys.length > 0))) return;
 
+            const isSameTranscript = state.lastTranscript === transcript;
+            if (!isSameTranscript) {
+                state.responses = {};
+                renderResults();
+            }
+            state.lastTranscript = transcript;
+
             // Get only enabled prompts in order
             const enabledPrompts = getEnabledPrompts();
             const orderedPrompts = Object.entries(enabledPrompts)
                 .sort(([,a], [,b]) => (a.order || 999) - (b.order || 999));
-            
+
             if (orderedPrompts.length === 0) {
                 showApiStatus('❌ No prompts enabled for processing', 'error');
                 return;
             }
 
+            const totalPrompts = orderedPrompts.length;
+            let completedCount = orderedPrompts.filter(([key]) => state.responses[key]).length;
+
+            if (completedCount === totalPrompts) {
+                progressSection.style.display = 'block';
+                progressFill.style.width = '100%';
+                statusText.textContent = '✅ All enabled prompts already processed.';
+                renderResults();
+                return;
+            }
+
             state.processing = true;
             updateUI();
-            
+
             progressSection.style.display = 'block';
-            progressFill.style.width = '0%';
-            
+            progressFill.style.width = `${(completedCount / totalPrompts) * 100}%`;
+
             try {
                 for (let i = 0; i < orderedPrompts.length; i++) {
                     const [key, data] = orderedPrompts[i];
-                    
+
+                    if (state.responses[key]) {
+                        continue;
+                    }
+
                     if (!state.autoRotate) {
                         statusText.textContent = `Processing: ${data.name}...`;
                     }
-                    progressFill.style.width = `${((i + 1) / orderedPrompts.length) * 100}%`;
-                    
+
                     const fullPrompt = `${data.prompt}\n\n---\n\n${transcript}`;
                     const response = await callGeminiAPI(fullPrompt, data.name);
                     state.responses[key] = response;
-                    
+                    completedCount++;
+
+                    renderResults();
+                    progressFill.style.width = `${(completedCount / totalPrompts) * 100}%`;
+
                     // Small delay between requests
-                    if (i < orderedPrompts.length - 1) {
+                    if (completedCount < totalPrompts) {
                         await new Promise(resolve => setTimeout(resolve, 1000));
                     }
                 }
-                
+
                 statusText.textContent = '✅ All enabled prompts processed successfully!';
-                renderResults();
-                
+
             } catch (error) {
                 statusText.textContent = `❌ Error: ${error.message}`;
                 console.error('Processing error:', error);


### PR DESCRIPTION
## Summary
- track the last processed transcript so cached responses are cleared only when needed
- render prompt results incrementally while processing and resume skipped prompts that already succeeded

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d56609fa50832899ca816b4d2745c0